### PR TITLE
fix: OpenAI API compatible adaptation

### DIFF
--- a/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
+++ b/api/core/model_runtime/model_providers/openai_api_compatible/llm/llm.py
@@ -150,6 +150,8 @@ class OAIAPICompatLargeLanguageModel(_CommonOAI_API_Compat, LargeLanguageModel):
             except json.JSONDecodeError as e:
                 raise CredentialsValidateFailedError('Credentials validation failed: JSON decode error')
 
+            if json_result['object'] == '':
+                json_result['object'] = 'chat.completion'
             if (completion_type is LLMMode.CHAT
                     and ('object' not in json_result or json_result['object'] != 'chat.completion')):
                 raise CredentialsValidateFailedError(
@@ -471,7 +473,7 @@ class OAIAPICompatLargeLanguageModel(_CommonOAI_API_Compat, LargeLanguageModel):
                     continue
 
                 # check payload indicator for completion
-                if finish_reason is not None:
+                if finish_reason is not None and finish_reason != '':
                     yield LLMResultChunk(
                         model=model,
                         prompt_messages=prompt_messages,


### PR DESCRIPTION
compatible with response object being empty and finish_reason being an empty string

# Description

compatible with response object being empty and finish_reason being an empty string

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ Y] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] Improvement, including but not limited to code refactoring, performance optimization, and UI/UX improvement
- [ ] Dependency upgrade

# How Has This Been Tested?
a open api compatiable model that the reponse is :
```json
{
    "choices": [
        {
            "delta": {
                "content": "您好"
            },
            "finish_reason": "",
            "index": 0
        }
    ],
    "created": 1712905253,
    "id": "67026348-f89a-11ee-8e9d-8ea53e763e28",
    "model": "xxxx",
    "object": "",
    "usage": null,
    "messages": null,
    "context": null
}
```

- [ ] TODO

# Suggested Checklist:

- [ Y] I have performed a self-review of my own code
- [ Y] I have commented my code, particularly in hard-to-understand areas
- [ Y] My changes generate no new warnings
- [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
- [ Y] `optional` I have made corresponding changes to the documentation 
- [ ] `optional` I have added tests that prove my fix is effective or that my feature works
- [ ] `optional` New and existing unit tests pass locally with my changes
